### PR TITLE
Fix meta keywords for blog posts

### DIFF
--- a/app/helpers/nest_helper.rb
+++ b/app/helpers/nest_helper.rb
@@ -24,6 +24,13 @@ module NestHelper
       #render :file => "#{Rails.root}/public/404", :layout => false, :status => :not_found
     end
   end
+
+  def meta_keywords
+    main_keywords = %w(kohrVid Jessica Ete Developer Rubyist Scala Go)
+    main_keywords += @post.tag_names if @post.present?
+
+    main_keywords.uniq(&:downcase).join(",")
+  end
 =begin
   def store_location
     session[:forwarding_url] = request.url if request.get?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,7 +15,6 @@ class Post < ActiveRecord::Base
   scope :drafts, proc { where(draft: true) }
   scope :published, proc { where(draft: false).order("published_at DESC") }
 
-
   def slug_candidates
     [
       :title,
@@ -37,5 +36,9 @@ class Post < ActiveRecord::Base
         date[year] = e.group_by { |post| post.published_at.month }
       end
     return date
+  end
+
+  def tag_names
+    tags.map(&:name)
   end
 end

--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -2,7 +2,7 @@
   %meta{ charset: "UTF-8" }
   %meta{ name: "viewport", content: "width=device-width, initial-scale=1" }
   %meta{ name: "description", content: "" }
-  %meta{ name: "keywords", content: "kohrVid,Jessica,Ete,Developer,Rubyist,Go" }
+  %meta{ name: "keywords", content: meta_keywords  }
   %meta{ name: "google-site-verification",
     content: "" }
   %title

--- a/spec/helpers/nest_helper_spec.rb
+++ b/spec/helpers/nest_helper_spec.rb
@@ -1,5 +1,35 @@
 require "rails_helper"
 
 RSpec.describe NestHelper, type: :helper do
+  describe "#meta_keywords" do
+    subject { meta_keywords }
 
+    it "returns the correct string on a normal page" do
+      is_expected.to eq(
+        "kohrVid,Jessica,Ete,Developer,Rubyist,Scala,Go"
+      )
+    end
+
+    context "blog posts" do
+      before do
+        @post = FactoryBot.create(:post)
+      end
+
+      it "returns the correct string with blog post tags included" do
+        allow_any_instance_of(Post).to receive(:tag_names)
+          .and_return(["cats","magic"])
+
+        is_expected.to eq(
+          "kohrVid,Jessica,Ete,Developer,Rubyist,Scala,Go,cats,magic"
+        )
+      end
+
+      it "returns a string of unique items" do
+        allow_any_instance_of(Post).to receive(:tag_names)
+          .and_return(["scala","ruby","go"])
+
+        is_expected.to eq("kohrVid,Jessica,Ete,Developer,Rubyist,Scala,Go,ruby")
+      end
+    end
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Post, type: :model do
     }.to change(Post, :count).by(1)
   end
 
-  context "#title" do
+  describe "#title" do
     it "must be present" do
       expect {
         Post.create(FactoryBot.attributes_for(:post, title: ""))
@@ -41,7 +41,7 @@ RSpec.describe Post, type: :model do
     end
   end
 
-  context "#body" do
+  describe "#body" do
     it "must be present" do
       expect {
         Post.create(FactoryBot.attributes_for(:post, body: ""))
@@ -136,6 +136,20 @@ RSpec.describe Post, type: :model do
     it "can have many tags" do
       expect(post_tag1).to be_valid
       expect(post_tag2).to be_valid
+    end
+
+    describe "#tag_names" do
+      subject { post.tag_names }
+      before do
+        tag1
+        tag2
+        post_tag1.save
+        post_tag2.save
+      end
+
+      it "returns the correct tag names in the expected order" do
+        is_expected.to eq(["#{tag1.name}", "#{tag2.name}"])
+      end
     end
 
 =begin


### PR DESCRIPTION
## What

Tags linked to blog posts should now appear in the page's list of meta keywords. Non-blog views should display meta tags as normal.