### PR TITLE
Prevent null URLs rendering a link

### DIFF
--- a/app/javascript/packs/utils/StringUtils.js
+++ b/app/javascript/packs/utils/StringUtils.js
@@ -10,7 +10,7 @@ export const truncate = (str, len) => {
 }
 
 export const handleString = (str) => {
-  if (str === undefined) {
+  if (str === undefined || str == null) {
     return ""
   } else {
    return str
@@ -18,7 +18,7 @@ export const handleString = (str) => {
 }
 
 export const renderLink = (link, url) => {
-  if (url !== undefined) {
+  if (handleString(url) !== "") {
    return <strong><a href={handleString(url)}>{link}</a></strong>
   }
 }

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -10,7 +10,7 @@
   what I've worked on in the past:
 
 %ul.projects
-  - @projects.published.each do |project|
+  - @projects.each do |project|
     %li
       - unless project.image.try(:thumb).nil?
         = link_to image_tag(project.image.thumb.url), image_path(project.image.url)

--- a/app/views/projects/list.html.haml
+++ b/app/views/projects/list.html.haml
@@ -10,7 +10,7 @@
   what I've worked on in the past:
 
 %ul.projects
-  - @projects.published.each do |project|
+  - @projects.each do |project|
     %li
       - unless project.image.try(:thumb).nil?
         = link_to image_tag(project.image.thumb.url), image_path(project.image.url)


### PR DESCRIPTION
## What

Null PDFs in the React frontend currently display a link to nowhere. This PR should fix that.