### PR TITLE
Order drafts by rank

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -5,6 +5,6 @@ class Client < ActiveRecord::Base
   validates :client_name, presence: true
   validates :client_url, presence: true
 
-  scope :drafts, proc { where(draft: true) }
+  scope :drafts, proc { where(draft: true).order("rank ASC") }
   scope :published, proc { where(draft: false).order("rank ASC") }
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,7 +3,7 @@ class Project < ApplicationRecord
   validates :name, presence: true
   validate :publishing_requirements
 
-  scope :drafts, proc { where(draft: true) }
+  scope :drafts, proc { where(draft: true).order("rank ASC") }
   scope :published, proc { where(draft: false).order("rank ASC") }
 
   # Note, currently unable to test published projects when :image appears in the

--- a/app/views/clients/list.html.haml
+++ b/app/views/clients/list.html.haml
@@ -24,6 +24,7 @@
           |
       .desc
         = link_to_if(admin_is_logged_in, "#{client.description}", client)
+        | rank: #{ client.rank }
       - if admin_is_logged_in
         %div
           = link_to 'Show', client

--- a/app/views/projects/list.html.haml
+++ b/app/views/projects/list.html.haml
@@ -30,6 +30,7 @@
             = project.languages.gsub(", ", "|")
       .desc
         = link_to_if(admin_is_logged_in, "#{project.description}", project)
+        | rank: #{ project.rank }
       - if admin_is_logged_in
         %div
           = link_to 'Show', project

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe Client, type: :model do
   end
 
   describe 'scopes' do
-    let(:client1) { FactoryBot.create(:client, draft: true) }
+    let(:client1) { FactoryBot.create(:client, draft: true, rank: 2) }
     let(:client2) { FactoryBot.create(:client, draft: false, rank: 2) }
-    let(:client3) { FactoryBot.create(:client, draft: true) }
+    let(:client3) { FactoryBot.create(:client, draft: true, rank: 1) }
     let(:client4) { FactoryBot.create(:client, draft: false, rank: 1) }
 
     before do
@@ -62,6 +62,10 @@ RSpec.describe Client, type: :model do
       it 'should not contain any public clients' do
         is_expected.to_not include(client2)
         is_expected.to_not include(client4)
+      end
+
+      it 'should be in order of ranking' do
+        is_expected.to eq([client3, client1])
       end
     end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Project, type: :model do
   end
 
   describe 'scopes' do
-    let(:project1) { FactoryBot.create(:project, draft: true) }
+    let(:project1) { FactoryBot.create(:project, draft: true, rank: 2) }
     let(:project2) { FactoryBot.create(:project, draft: false, rank: 2) }
-    let(:project3) { FactoryBot.create(:project, draft: true) }
+    let(:project3) { FactoryBot.create(:project, draft: true, rank: 1) }
     let(:project4) { FactoryBot.create(:project, draft: false, rank: 1) }
 
     before do
@@ -70,6 +70,10 @@ RSpec.describe Project, type: :model do
       it 'should not contain any public projects' do
         is_expected.to_not include(project2)
         is_expected.to_not include(project4)
+      end
+
+      it 'should be in order of ranking' do
+        is_expected.to eq([project3, project1])
       end
     end
 


### PR DESCRIPTION
## What

It's hard to manage projects in the admin view when I can't see the
order in which they will appear. This should fix that.