### PR TITLE
Convert navigation stylesheet into an HAML file

### DIFF
--- a/app/assets/stylesheets/navigation.scss.haml
+++ b/app/assets/stylesheets/navigation.scss.haml
@@ -8,8 +8,8 @@
 
 #navbar {
   background-color: $black;
-  background: $black image-url("nav.jpg");
-  background-image: -webkit-image-set(image-url("nav.jpg") 1x, image-url("nav-2x.jpg") 2x);
+  background: $black #{ asset_url('nav.jpg') };
+  background-image: -webkit-image-set(#{ asset_url('nav.jpg') } 1x, #{ asset_url('nav-2x.jpg') } 2x);
   background-repeat: no-repeat;
   background-position: 0 0;
   background-attachment: fixed;

--- a/app/assets/stylesheets/nest.scss
+++ b/app/assets/stylesheets/nest.scss
@@ -16,7 +16,7 @@ $rouge: #9F0000;
 @import "coderay.scss";
 @import "dividers.scss";
 @import "form.scss";
-@import "navigation.scss";
+@import "navigation.scss.haml";
 @import "padding.scss";
 @import "posts.scss";
 @import "utils.scss";


### PR DESCRIPTION
I'm not convinced that there's a way to refer to the image assets within .scss files in the latest version of Sprockets. If there is, most probably this only works inconsistently. I have decided to convert the
old navigation file into an HAML template in the hopes that the standard HAML template helpers can be used instead.

TLDR: Navigation backgrounds are back and they're tacky AF!