### PR TITLE
Increase maximum length of blog titles

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,7 +7,7 @@ class Post < ActiveRecord::Base
   has_many :tags, -> { distinct }, through: :post_tags
   has_many :comments, dependent: :destroy
 
-  validates :title, presence: true, length: { maximum: 50 }, uniqueness: true
+  validates :title, presence: true, length: { maximum: 75 }, uniqueness: true
   validates :body, length: { maximum: 20000 }
   validates :rich_text_body, presence: true,
     length: { minimum: 14, maximum: 20010 }, uniqueness: true

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe Post, type: :model do
       expect(p.errors[:title]).to_not be_empty
     end
 
-    it "must be no more than 50 characters long" do
+    it "must be no more than 75 characters long" do
       expect {
         Post.create(
-          FactoryBot.attributes_for(:post, title: "m"*51)
+          FactoryBot.attributes_for(:post, title: "m"*76)
         )
       }.to_not change(Post, :count)
     end


### PR DESCRIPTION
75 characters is probably a good limit if you take into account the use of special characters in a title.