### PR TITLE
Add formatting for blog post dates

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -33,6 +33,18 @@ class Post < ActiveRecord::Base
     end
   end
 
+  def published_format
+    published_at.strftime(
+      "Published %e#{published_at.day.ordinal} %B %Y at %I:%M%P"
+    ) if published_at.present?
+  end
+
+  def updated_format
+    updated_at.strftime(
+      "(Last Updated %e#{updated_at.day.ordinal} %B %Y at %I:%M%P)"
+    ) if published_at.present? && (published_at.to_date != updated_at.to_date)
+  end
+
   def self.post_date
     date = {}
 

--- a/app/views/posts/_post.html.haml
+++ b/app/views/posts/_post.html.haml
@@ -5,8 +5,14 @@
     %small.smaller-text
       %em
         (#{ pluralize(post.comments.count, "comment") })
-  = truncate_body(post.rich_text_body)
-  = link_to "[Read more...]", post
+
+  %em
+    = post.published_format
+
+  .p-t-1r
+    = truncate_body(post.rich_text_body)
+    = link_to "[Read more...]", post
+
   %br
   - if admin_is_logged_in
     %ul.divider-list.p-l-0

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -6,10 +6,10 @@
     = @post.title
   %p
     %em
-      = @post.published_at.strftime("Published %e#{@post.published_at.day.ordinal} %B %Y at %H:%M") if @post.published_at.present?
-    %br
+      = @post.published_format
+      &nbsp;
     %em.smaller-text
-      = @post.updated_at.strftime("(Last Updated %e#{@post.updated_at.day.ordinal} %B %Y at %H:%M)") if @post.published_at.present? && (@post.published_at.to_date != @post.updated_at.to_date)
+      = @post.updated_format
 
   - unless !@post.draft?
     #error_explanation.alerts

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -115,6 +115,33 @@ RSpec.describe Post, type: :model do
     end
   end
 
+  context 'date formatters' do
+    let(:time) { Time.new(2020,01,8,18,10) }
+
+    let(:post) do
+      FactoryBot.create(:post, published_at: time )
+    end
+
+    before(:each) do
+      post
+      Timecop.freeze(time + 1.day) do
+        post.update(title: "new title")
+      end
+    end
+
+    context '#published_format' do
+      it 'should format the date correctly' do
+        expect(post.published_format).to eq "Published  8th January 2020 at 06:10pm"
+      end
+    end
+
+    context '#updated_format' do
+      it 'should format the date correctly' do
+        expect(post.updated_format).to eq "(Last Updated  9th January 2020 at 06:10pm)"
+      end
+    end
+  end
+
   describe 'scopes' do
     let(:post1) { FactoryBot.create(:post, draft: true) }
     let(:post2) { FactoryBot.create(:post) }


### PR DESCRIPTION
Have added new methods to handle the formatting of the published_at and updated_at dates so that this logic can be moved out of the post views and into the model. Have added tests and tweaked the styling. Publishing dates should now appear in posts#index (which I think is a little better for SEO but again idk).