### PR TITLE
Format jobs end date

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is the repo for my site.
 * [Set up](#set-up)
 * [Run locally](#run-locally)
 * [Deploy to production](#deploy-to-production)
+* [Run test suite](#run-test-suite)
 
 <!-- vim-markdown-toc -->
 
@@ -51,3 +52,13 @@ This depends on the following buildpacks:
 
   * heroku/ruby
   * heroku/nodejs
+
+## Run test suite
+
+Test are written in RSpec
+
+    rspec
+
+Guard is configured to run when changes are made to specific tests:
+
+    guard

--- a/app/helpers/nest_helper.rb
+++ b/app/helpers/nest_helper.rb
@@ -6,11 +6,11 @@ module NestHelper
   def current_user?(user)
     user == current_user
   end
-  
+
   def current_user_id?(user_id)
     user_id == current_user.id
   end
-  
+
   def redirect_to_login
     unless user_signed_in?
       flash[:error] = "Please log in"
@@ -31,6 +31,15 @@ module NestHelper
 
     main_keywords.uniq(&:downcase).join(",")
   end
+
+  def list_current_errors
+    instance_variables.select do |ivar|
+      instance_variable_get(ivar).respond_to?(:errors)
+    end.map do |model|
+      instance_variable_get(model).errors.try(:full_messages)
+    end.flatten
+  end
+
 =begin
   def store_location
     session[:forwarding_url] = request.url if request.get?

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -13,4 +13,12 @@ class Job < ApplicationRecord
       errors[:start_date] << "must be in the past"
     end
   end
+
+  def format_end_date
+    if end_date.present? && end_date.past?
+      end_date.strftime("%b %Y")
+    else
+      "Present"
+    end
+  end
 end

--- a/app/views/layouts/_alerts.html.haml
+++ b/app/views/layouts/_alerts.html.haml
@@ -6,12 +6,9 @@
           = value
         %a.close{ href: "#" }
           &times;
-        - [ @user, @contact, @client, @comment, @post, @tag ].each do |model|
-          - if model.present?
-            - @object = model
-        - if @object.present? && @object.errors.any?
-          The form contains #{ pluralize(@object.errors.count, "error") }.
+        - if list_current_errors.any?
+          The form contains #{ pluralize(list_current_errors.count, "error") }.
           %ul
-            - @object.errors.full_messages.each do |msg|
+            - list_current_errors.each do |msg|
               %li
                 = msg

--- a/app/views/nest/_job.html.haml
+++ b/app/views/nest/_job.html.haml
@@ -4,7 +4,7 @@
       %strong
         = link_to job.company_name, job.company_website
       %br
-      #{job.start_date.strftime("%b %Y")} - #{job.end_date.strftime("%b %Y")}
+      #{job.start_date.strftime("%b %Y")} - #{job.format_end_date}
 
     .display-inline.col-lg-9.col-md-9.col-sm-9.col-xs-8
       = job.description

--- a/spec/helpers/nest_helper_spec.rb
+++ b/spec/helpers/nest_helper_spec.rb
@@ -31,5 +31,25 @@ RSpec.describe NestHelper, type: :helper do
         is_expected.to eq("kohrVid,Jessica,Ete,Developer,Rubyist,Scala,Go,ruby")
       end
     end
+
+    context "list_current_errors" do
+      it "should return an empty list if there is no model" do
+        expect(list_current_errors).to be_empty
+      end
+
+      it "should return an empty list if there are no errors" do
+        @tag = FactoryBot.build(:tag)
+        @tag.errors
+
+        expect(list_current_errors).to be_empty
+      end
+
+      it "should list errors if a model with errors ispresent" do
+        @tag = Tag.new
+        @tag.save
+
+        expect(list_current_errors).to include "Name can't be blank"
+      end
+    end
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Job, type: :model do
   let(:subject) { Job.new }
 
-  context "title" do
+  context "#title" do
     before(:each) do
       subject.save
     end
@@ -18,7 +18,7 @@ RSpec.describe Job, type: :model do
     end
   end
 
-  context "company_name" do
+  context "#company_name" do
     before(:each) do
       subject.save
     end
@@ -29,10 +29,10 @@ RSpec.describe Job, type: :model do
     end
   end
 
-  context "company_website" do
+  context "#company_website" do
   end
 
-  context "start_date" do
+  context "#start_date" do
     it "should be present" do
       subject.save
       expect(subject.errors[:start_date]).to_not be_nil
@@ -45,20 +45,56 @@ RSpec.describe Job, type: :model do
           :job,
           start_date: DateTime.new(2030,01,13)
         )
-        
+
         subject.save
 
-        expect(subject.errors[:start_date]).to_not be_nil 
+        expect(subject.errors[:start_date]).to_not be_nil
         expect(subject.errors[:start_date]).to_not be_empty
         expect(subject.errors[:start_date]).to include "must be in the past"
       end
     end
   end
 
-  context "end_date" do
+  context "#end_date" do
   end
 
-  context "description" do
+  context "#format_end_date" do
+    let(:time) { Time.local(2020,01,11,23,51) }
+
+    it "should return the word Present if the end_date is nil" do
+      job = FactoryBot.build(:job, end_date: nil)
+
+      Timecop.freeze(time) do
+        expect(job.format_end_date).to eq "Present"
+      end
+    end
+
+    it "should return the word Present if the end_date is in the future" do
+      job = FactoryBot.build(:job, end_date: (time.to_date + 1.day))
+
+      Timecop.freeze(time) do
+        expect(job.format_end_date).to eq "Present"
+      end
+    end
+
+    it "should return the word Present if the end_date is current date" do
+      job = FactoryBot.build(:job, end_date: time)
+
+      Timecop.freeze(time) do
+        expect(job.format_end_date).to eq "Present"
+      end
+    end
+
+    it "should return the correct date if the end_date is in the past" do
+      job = FactoryBot.build(:job, end_date: (time - 1.day))
+
+      Timecop.freeze(time) do
+        expect(job.format_end_date).to eq "Jan 2020"
+      end
+    end
+  end
+
+  context "#description" do
     before(:each) do
       subject.save
     end


### PR DESCRIPTION
Current jobs will display the word "Present" instead of an end date.
Have also updated the README slightly and cleaned up the alerts partial