### PR TITLE
Fix Heroku assets issue once and for all

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = '1.1'
 
 # Add additional assets to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join('node_modules')


### PR DESCRIPTION
According to [this Stack Overflow post](https://stackoverflow.com/questions/58035749/rails-6-deployed-on-heroku-wont-update-stylesheets), the only way to resolve the issue with heroku assets in rails 6 is to change the assets version number to `1.1`.