### PR TITLE
Removing Heroku Deflater gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,6 @@ end
 
 group :production do
   gem 'dotenv'
-  gem 'heroku-deflater'
   gem "google-cloud-storage", "~> 1.11", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,8 +272,6 @@ GEM
     haml (5.2.1)
       temple (>= 0.8.0)
       tilt
-    heroku-deflater (0.6.3)
-      rack (>= 1.4.5)
     httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -543,7 +541,6 @@ DEPENDENCIES
   guard-rspec
   guard-shell
   haml
-  heroku-deflater
   image_processing (~> 1.2)
   jbuilder (~> 2.5)
   jquery-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module KohrVid
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.middleware.use Rack::Deflater
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
The previous PR broke all of the assets in Heroku. Currently assets are
a complete mess but I'll fix that later